### PR TITLE
fix(tab-bar): make background transparent and set positioning to absolute

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,6 +40,9 @@ export default function TabLayout() {
           height: 80,
           paddingTop: 8,
           borderTopWidth: 0,
+          backgroundColor: "transparent",
+          position: "absolute",
+          bottom: 0
         },
       }}
     >


### PR DESCRIPTION

- Updated `tabBarStyle` to use a transparent background
- Changed the positioning to absolute to allow content scrolling underneath

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated tab bar styling to be transparent and positioned at the bottom of the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->