### PR TITLE
fix(upload): Resolve default avatar upload failure in release build

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>

--- a/ios/Polkassembly/Info.plist
+++ b/ios/Polkassembly/Info.plist
@@ -53,6 +53,8 @@
     <string>Allow $(PRODUCT_NAME) to access your Face ID biometric data.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Allow $(PRODUCT_NAME) to access your microphone</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Allow $(PRODUCT_NAME) to access your photos</string>
     <key>NSUserActivityTypes</key>
     <array>
       <string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>

--- a/lib/net/queries/profile/useEditProfile.ts
+++ b/lib/net/queries/profile/useEditProfile.ts
@@ -4,7 +4,7 @@ import { getUserIdFromStorage } from "../utils";
 import { buildUserByIdQueryKey } from "./useGetUserById";
 import { UserProfile } from "@/lib/types";
 
-interface EditProfileParams {
+export interface EditProfileParams {
   email?: string;
   username?: string;
   bio?: string;
@@ -59,11 +59,15 @@ function useEditProfile() {
       if (context?.previousData) {
         queryClient.setQueryData(buildUserByIdQueryKey(id), context.previousData);
       }
+
+      console.error("An error occurred while editing the profile:", error);
+      throw error;
     },
     onSuccess: () => {
-      // Optionally, you could also update the cache with the fresh data from the server,
-      // but here we simply invalidate the query to refetch it.
-      queryClient.invalidateQueries({ queryKey: [buildUserByIdQueryKey(id)] });
+      // Since the user profile updation doesn't return any ids, we don't need to invalidate any queries
+      // We can keep the manually updated cache as it is
+      
+      // queryClient.invalidateQueries({ queryKey: [buildUserByIdQueryKey(id)] });
     },
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "expo-constants": "~17.0.3",
         "expo-font": "~13.0.1",
         "expo-haptics": "~14.0.1",
+        "expo-image-manipulator": "^13.0.6",
         "expo-image-picker": "^16.0.6",
         "expo-linear-gradient": "~14.0.2",
         "expo-linking": "~7.0.5",
@@ -7353,6 +7354,17 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.0.0.tgz",
       "integrity": "sha512-Eg+5FHtyzv3Jjw9dHwu2pWy4xjf8fu3V0Asyy42kO+t/FbvW/vjUixpTjPtgKQLQh+2/9Nk4JjFDV6FwCnF2ZA==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-13.0.6.tgz",
+      "integrity": "sha512-Rz8Kcfx1xYm0AsIDi6zfKYUDnwCP8edgYXWb00KAkzOF8bDxwzTrnvESWhCiveM4IB3fojjLpNeENME34p3bzA==",
+      "dependencies": {
+        "expo-image-loader": "~5.0.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "expo-constants": "~17.0.3",
     "expo-font": "~13.0.1",
     "expo-haptics": "~14.0.1",
+    "expo-image-manipulator": "^13.0.6",
     "expo-image-picker": "^16.0.6",
     "expo-linear-gradient": "~14.0.2",
     "expo-linking": "~7.0.5",


### PR DESCRIPTION
- Solve local uri issue by copying file to cache and using expo-image-manipulator for compression and to get a valid URI. (a rather unconventional method)
- Skip profile data invalidation in editUserProfile to avoid redundant refetching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced profile image uploads now automatically compress and resize images for a smoother and faster profile update experience.
  - On iOS, the app now requests permission to access your photo library, improving the integration of photo-based features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->